### PR TITLE
Feature/sat 955 implement instructions in the arch typesript sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,115 @@ console.log('Arch transaction ID:', txid);
 - **Signature**: `Uint8Array (64 bytes)`
 - **RuntimeTransaction**: `{ version, signatures, message }`
 
+## System Instruction Helpers
+
+The SDK provides low-level helper functions for constructing system instructions compatible with the Arch blockchain. These helpers serialize instruction data in a format expected by the on-chain Rust programs, making it easy to create, transfer, and manage accounts from TypeScript.
+
+### `createAccount`
+
+Creates a new account on the blockchain.
+
+**Parameters:**
+
+- `fromPubkey: Pubkey` — Funding account public key (signer, writable)
+- `toPubkey: Pubkey` — New account public key (signer, writable)
+- `lamports: bigint` — Number of lamports to transfer to the new account
+- `space: bigint` — Number of bytes of memory to allocate
+- `owner: Pubkey` — Program that will own the new account
+
+**Example:**
+
+```typescript
+const ix = createAccount(funder, newAccount, 1000n, 128n, ownerProgramId);
+```
+
+---
+
+### `createAccountWithAnchor`
+
+Creates a new account and anchors it to a specific UTXO (e.g., for Bitcoin integration).
+
+**Parameters:**
+
+- `fromPubkey: Pubkey` — Funding account public key (signer, writable)
+- `toPubkey: Pubkey` — New account public key (signer, writable)
+- `lamports: bigint` — Number of lamports to transfer
+- `space: bigint` — Number of bytes of memory to allocate
+- `owner: Pubkey` — Program that will own the new account
+- `txid: string` — 64-character hex string of the UTXO transaction ID
+- `vout: number` — Output index of the UTXO
+
+**Example:**
+
+```typescript
+const ix = createAccountWithAnchor(
+  funder,
+  newAccount,
+  1000n,
+  128n,
+  ownerProgramId,
+  'aabbcc...ff', // 64-char hex string
+  0,
+);
+```
+
+---
+
+### `transfer`
+
+Transfers lamports from one account to another.
+
+**Parameters:**
+
+- `fromPubkey: Pubkey` — Sender account public key (signer, writable)
+- `toPubkey: Pubkey` — Recipient account public key (writable)
+- `lamports: bigint` — Amount to transfer
+
+**Example:**
+
+```typescript
+const ix = transfer(sender, recipient, 500n);
+```
+
+---
+
+### `assign`
+
+Assigns a new owner (program) to an account.
+
+**Parameters:**
+
+- `pubkey: Pubkey` — Account to reassign (signer, writable)
+- `owner: Pubkey` — New owner program public key
+
+**Example:**
+
+```typescript
+const ix = assign(account, newOwnerProgramId);
+```
+
+---
+
+### `allocate`
+
+Allocates space in an account without funding it.
+
+**Parameters:**
+
+- `pubkey: Pubkey` — Account to allocate space for (signer, writable)
+- `space: bigint` — Number of bytes to allocate
+
+**Example:**
+
+```typescript
+const ix = allocate(account, 256n);
+```
+
+---
+
+**Usage Note:**
+After constructing an instruction with these helpers, use the SDK's serialization utilities (see above) to serialize and send the instruction as part of a transaction.
+
 ## Example: Creating and Sending a Transaction
 
 ```typescript

--- a/src/system-instructions/system-instructions.ts
+++ b/src/system-instructions/system-instructions.ts
@@ -1,0 +1,151 @@
+import { Instruction } from '../struct/instruction';
+import { AccountMeta } from '../struct/account';
+import { Pubkey } from '../struct/pubkey';
+import { SYSTEM_PROGRAM_ID } from '../constants';
+
+// Converts a number (u32) to a 4-byte Uint8Array in little-endian order.
+export const u32ToLeBytes = (num: number): Uint8Array => {
+  const arr = new Uint8Array(4);
+  new DataView(arr.buffer).setUint32(0, num, true);
+  return arr;
+};
+
+// Converts a bigint (u64) to an 8-byte Uint8Array in little-endian order.
+export const u64ToLeBytes = (num: bigint): Uint8Array => {
+  const arr = new Uint8Array(8);
+  const view = new DataView(arr.buffer);
+  view.setUint32(0, Number(num & 0xffffffffn), true); // lower 32 bits
+  view.setUint32(4, Number((num >> 32n) & 0xffffffffn), true); // Upper 32 bits
+  return arr;
+};
+
+// Converts a 64-character hex string (representing 32 bytes) to a Uint8Array.
+export const hexStringToUint8Array = (hex: string): Uint8Array => {
+  if (hex.length !== 64)
+    throw new Error('txid hex string must be 64 characters');
+  return new Uint8Array(Buffer.from(hex, 'hex'));
+};
+
+export const createAccount = (
+  fromPubkey: Pubkey,
+  toPubkey: Pubkey,
+  lamports: bigint,
+  space: bigint,
+  owner: Pubkey,
+): Instruction => {
+  const discriminant = u32ToLeBytes(0);
+  const lamportsArray = u64ToLeBytes(lamports);
+  const spaceArray = u64ToLeBytes(space);
+  const ownerBytes = owner;
+  const data = new Uint8Array([
+    ...discriminant,
+    ...lamportsArray,
+    ...spaceArray,
+    ...ownerBytes,
+  ]);
+
+  const accounts: AccountMeta[] = [
+    { pubkey: fromPubkey, is_signer: true, is_writable: true },
+    { pubkey: toPubkey, is_signer: true, is_writable: true },
+  ];
+
+  return {
+    program_id: SYSTEM_PROGRAM_ID,
+    accounts,
+    data,
+  };
+};
+
+export const createAccountWithAnchor = (
+  fromPubkey: Pubkey,
+  toPubkey: Pubkey,
+  lamports: bigint,
+  space: bigint,
+  owner: Pubkey,
+  txid: string,
+  vout: number,
+): Instruction => {
+  const txidBytes = hexStringToUint8Array(txid);
+  if (txidBytes.length !== 32) {
+    throw new Error('txid must be 32 bytes');
+  }
+
+  const discriminant = u32ToLeBytes(1);
+  const lamportsArray = u64ToLeBytes(lamports);
+  const spaceArray = u64ToLeBytes(space);
+  const ownerBytes = owner;
+  const voutArray = u32ToLeBytes(vout);
+
+  const data = new Uint8Array([
+    ...discriminant,
+    ...lamportsArray,
+    ...spaceArray,
+    ...ownerBytes,
+    ...txidBytes,
+    ...voutArray,
+  ]);
+
+  const accounts: AccountMeta[] = [
+    { pubkey: fromPubkey, is_signer: true, is_writable: true },
+    { pubkey: toPubkey, is_signer: true, is_writable: true },
+  ];
+
+  return {
+    program_id: SYSTEM_PROGRAM_ID,
+    accounts,
+    data,
+  };
+};
+
+export const assign = (pubkey: Pubkey, owner: Pubkey): Instruction => {
+  const discriminant = u32ToLeBytes(2);
+  const ownerBytes = owner;
+  const data = new Uint8Array([...discriminant, ...ownerBytes]);
+
+  const accounts: AccountMeta[] = [
+    { pubkey, is_signer: true, is_writable: true },
+  ];
+
+  return {
+    program_id: SYSTEM_PROGRAM_ID,
+    accounts,
+    data,
+  };
+};
+
+export const transfer = (
+  fromPubkey: Pubkey,
+  toPubkey: Pubkey,
+  lamports: bigint,
+): Instruction => {
+  const discriminant = u32ToLeBytes(4);
+  const lamportsBytes = u64ToLeBytes(lamports);
+  const data = new Uint8Array([...discriminant, ...lamportsBytes]);
+
+  const accounts: AccountMeta[] = [
+    { pubkey: fromPubkey, is_signer: true, is_writable: true },
+    { pubkey: toPubkey, is_signer: false, is_writable: true },
+  ];
+
+  return {
+    program_id: SYSTEM_PROGRAM_ID,
+    accounts,
+    data,
+  };
+};
+
+export const allocate = (pubkey: Pubkey, space: bigint): Instruction => {
+  const discriminant = u32ToLeBytes(5);
+  const spaceArray = u64ToLeBytes(space);
+  const data = new Uint8Array([...discriminant, ...spaceArray]);
+
+  const accounts: AccountMeta[] = [
+    { pubkey, is_signer: true, is_writable: true },
+  ];
+
+  return {
+    program_id: SYSTEM_PROGRAM_ID,
+    accounts,
+    data,
+  };
+};


### PR DESCRIPTION
Implement helper methods for creating instructions in the typescript sdk, according to the instruction from the arch-network.
Improve documentation to support helper methods added.